### PR TITLE
Migrate to Native AOT compilation for CongCraft.Game

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,15 +24,19 @@ jobs:
           - os: macos-14
             rid: osx-arm64
             name: CongCraft-macOS-arm64
+            binary: CongCraft.Game
           - os: macos-13
             rid: osx-x64
             name: CongCraft-macOS-x64
+            binary: CongCraft.Game
           - os: ubuntu-latest
             rid: linux-x64
             name: CongCraft-linux-x64
+            binary: CongCraft.Game
           - os: windows-latest
             rid: win-x64
             name: CongCraft-windows-x64
+            binary: CongCraft.Game.exe
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -41,22 +45,19 @@ jobs:
         with:
           dotnet-version: '8.0.x'
 
-      - name: Publish self-contained
+      - name: Publish Native AOT
         run: >
           dotnet publish src/CongCraft.Game/CongCraft.Game.csproj
           --configuration Release
           --runtime ${{ matrix.rid }}
-          --self-contained true
-          -p:PublishSingleFile=true
-          -p:IncludeNativeLibrariesForSelfExtract=true
           --output ./publish
 
       - name: Archive (Unix)
         if: runner.os != 'Windows'
         run: |
           cd publish
-          chmod +x CongCraft.Game || true
-          tar -czf ../${{ matrix.name }}.tar.gz *
+          chmod +x ${{ matrix.binary }}
+          zip -r ../${{ matrix.name }}.zip ${{ matrix.binary }} *.dylib *.so 2>/dev/null || zip -r ../${{ matrix.name }}.zip ${{ matrix.binary }}
 
       - name: Archive (Windows)
         if: runner.os == 'Windows'
@@ -66,9 +67,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.name }}
-          path: |
-            ${{ matrix.name }}.tar.gz
-            ${{ matrix.name }}.zip
+          path: ${{ matrix.name }}.zip
 
   release:
     needs: build
@@ -86,6 +85,4 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
-          files: |
-            artifacts/*.tar.gz
-            artifacts/*.zip
+          files: artifacts/*.zip

--- a/src/CongCraft.Engine/CongCraft.Engine.csproj
+++ b/src/CongCraft.Engine/CongCraft.Engine.csproj
@@ -4,6 +4,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Silk.NET" Version="2.21.0" />

--- a/src/CongCraft.Game/CongCraft.Game.csproj
+++ b/src/CongCraft.Game/CongCraft.Game.csproj
@@ -5,6 +5,11 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+
+    <!-- Native AOT: kompiliert zu nativem Maschinencode -->
+    <PublishAot>true</PublishAot>
+    <StripSymbols>true</StripSymbols>
+    <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="../CongCraft.Engine/CongCraft.Engine.csproj" />


### PR DESCRIPTION
## Summary
This PR migrates the CongCraft.Game project from self-contained framework-dependent deployment to Native AOT (Ahead-of-Time) compilation. This produces standalone native executables with improved startup time and reduced memory footprint.

## Key Changes

- **Enable Native AOT compilation**: Added `PublishAot=true` to CongCraft.Game.csproj with supporting options (`StripSymbols`, `InvariantGlobalization`)
- **Mark Engine library as AOT-compatible**: Added `IsAotCompatible=true` to CongCraft.Engine.csproj to ensure compatibility with AOT compilation
- **Update release workflow**: 
  - Replaced self-contained publish flags with Native AOT approach
  - Changed artifact format from `.tar.gz` (Unix) to `.zip` (all platforms) for consistency
  - Updated archive creation to include native libraries (`.dylib`, `.so`) alongside the binary
  - Simplified artifact upload to only use `.zip` format
  - Added `binary` matrix variable to handle platform-specific executable names (`.exe` on Windows)

## Implementation Details

The Native AOT compilation approach:
- Compiles .NET code directly to native machine code at publish time
- Eliminates the need for the .NET runtime to be present on target machines
- Produces smaller, faster-starting executables
- Requires AOT compatibility across all referenced libraries (hence the Engine library update)
- Uses `InvariantGlobalization=true` for reduced binary size (no culture-specific data)
- Strips debug symbols with `StripSymbols=true` for smaller binaries

https://claude.ai/code/session_01KSAp15wW5bL1TZ3NgAfVec