### PR TITLE
Native AOT build with M1 signing and PR pre-releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - 'v*'
+  pull_request:
+    branches: [main, master]
   workflow_dispatch:
 
 jobs:
@@ -68,6 +70,42 @@ jobs:
         with:
           name: ${{ matrix.name }}
           path: ${{ matrix.name }}.zip
+
+  pre-release:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create testing tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="testing-pr${{ github.event.pull_request.number }}-$(echo ${{ github.sha }} | cut -c1-7)"
+          git tag "$TAG"
+          git push origin "$TAG"
+          echo "TAG=$TAG" >> "$GITHUB_ENV"
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Create Pre-Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.TAG }}
+          name: "Testing: PR #${{ github.event.pull_request.number }}"
+          prerelease: true
+          generate_release_notes: false
+          body: |
+            Pre-release build from PR #${{ github.event.pull_request.number }}
+            Branch: `${{ github.head_ref }}`
+            Commit: ${{ github.sha }}
+          files: artifacts/*.zip
 
   release:
     needs: build


### PR DESCRIPTION
## Summary
- Native AOT statt self-contained single-file publish — fixt GLFW crash auf macOS
- Ad-hoc Code-Signing für macOS Binary — Gatekeeper akzeptiert das Executable
- Intel Mac (osx-x64) entfernt — nur noch Apple Silicon
- PR-triggered Pre-Releases — jeder PR erstellt automatisch testing Tag + Pre-Release

## Test plan
- [ ] PR-Workflow baut erfolgreich für alle 3 Plattformen
- [ ] Testing-Tag und Pre-Release werden erstellt
- [ ] macOS arm64 Binary startet ohne Gatekeeper-Blockade
- [ ] v* Tag erstellt normalen Release
