### PR TITLE
fix: sky renderer was covering terrain due to disabled depth test

### DIFF
--- a/src/CongCraft.Engine/Environment/SkyRenderer.cs
+++ b/src/CongCraft.Engine/Environment/SkyRenderer.cs
@@ -31,8 +31,10 @@ public sealed class SkyRenderer : ISystem
 
     public void Render(GameTime time)
     {
+        // Sky vertex shader sets Z=0.999 (near far plane) so depth test against
+        // already-drawn terrain (Z < 0.999) correctly clips the sky behind geometry.
+        // DepthMask=false prevents the sky from overwriting terrain depth values.
         _gl.DepthMask(false);
-        _gl.Disable(EnableCap.DepthTest);
 
         _skyShader.Use();
         _skyShader.SetUniform("uZenithColor", _dayNight.ZenithColor);
@@ -41,7 +43,6 @@ public sealed class SkyRenderer : ISystem
         _skyShader.SetUniform("uTime", time.TotalTimeF);
         _quad.Draw();
 
-        _gl.Enable(EnableCap.DepthTest);
         _gl.DepthMask(true);
     }
 


### PR DESCRIPTION
SkyVertex already sets gl_Position.z = 0.999 (near the far plane) so that depth testing against rendered geometry (terrain/vegetation at z < 0.999) would naturally mask the sky. However, _gl.Disable(EnableCap.DepthTest) defeated this: sky fragments wrote over every terrain pixel regardless of depth, making the world look like an empty skybox.

Fix: remove the Disable/Enable(DepthTest) pair and keep only DepthMask(false). With depth test active (GL_LESS), terrain depth values < 0.999 block sky fragments, so sky is only visible where no geometry was drawn — the intended skybox-last rendering pattern.

This was also the root cause of "textures not loading": textures were correct but the sky was painting over the entire scene each frame.

https://claude.ai/code/session_01AL9nbAyJepc3TQnpxEQzQe

## Summary

<!-- Brief description of what this PR does -->

## Changes

<!-- List the key changes -->
-

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI/CD / DevOps

## Game Area

<!-- Which system(s) does this affect? -->
- [ ] Combat
- [ ] Magic / Spells
- [ ] Inventory / Equipment
- [ ] Crafting
- [ ] Quests / Dialogue
- [ ] World Generation
- [ ] Rendering / Graphics
- [ ] Audio
- [ ] Save / Load
- [ ] UI / HUD
- [ ] Other

## Testing

- [ ] Unit tests pass (`dotnet test`)
- [ ] Manual gameplay testing done
- [ ] No new warnings introduced

## Screenshots / Videos

<!-- If visual changes, add screenshots or recordings -->

## Checklist

- [ ] Code follows project conventions
- [ ] Self-reviewed my own code
- [ ] No new compiler warnings
- [ ] Tests added/updated for changes
- [ ] Documentation updated if needed
