### PR TITLE
fix: auto-start in Playing mode - fixes broken gameplay

### DIFF
--- a/create-pr.sh
+++ b/create-pr.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+set -e
+
+cd /workspaces/cong-craft
+
+gh pr create \
+  --title "feat: integrate generated dark-fantasy texture assets" \
+  --body "## Summary
+
+Integrates 35 generated dark-fantasy style texture assets into the project, replacing procedural fallback textures with proper PNG files.
+
+### Assets Added
+
+**Terrain Textures** (512x512, tileable):
+- \`terrain_grass.png\` - Dark earthy grass
+- \`terrain_stone.png\` - Weathered stone
+- \`terrain_dirt.png\` - Dark brown dirt
+- \`terrain_snow.png\` - Frost-touched snow
+- \`terrain_path.png\` - Worn travel path
+
+**Material Textures** (512x512, tileable):
+- \`mat_metal.png\` - Dark iron/steel
+- \`mat_leather.png\` - Worn leather
+- \`mat_skin.png\` - Character skin
+- \`mat_wood.png\` - Aged oak
+- \`mat_fabric.png\` - Rough woven cloth
+
+**Water Maps** (512x512):
+- \`water_normal.png\` - Normal map for water surface
+- \`water_dudv.png\` - Distortion map for water refraction
+
+**Icons** (64x64, transparent):
+- 3 weapon icons (rusty sword, dark sword, bone club)
+- 4 armor icons (leather helm, chain armor, leather armor, iron greaves)
+- 6 material icons (wolf pelt, iron ore, wood, cloth, bone, troll hide)
+- 2 item icons (herb, strength potion)
+- 1 clothing icon (wolf cloak)
+
+**Portraits** (128x128):
+- Player portrait
+- Guard NPC portrait
+- Elder Maren NPC portrait
+
+**Particle Sprites** (64x64, transparent):
+- Fire, rain, blood, magic particles
+
+### Code Changes
+
+- Extended \`AssetPaths\` with \`Icons\`, \`Portraits\`, \`Particles\` helper properties
+- Added \`IconFile()\`, \`PortraitFile()\`, \`ParticleFile()\` convenience methods
+- Updated \`.gitignore\` for temporary integration files
+
+### How It Works
+
+The existing \`TextureLoader.LoadOrGenerate()\` system automatically picks up the new PNG files:
+- Terrain textures loaded in \`TerrainSystem\`
+- Material textures loaded in \`MaterialTextures\`
+- Falls back to procedural generation if files are missing
+
+### Testing
+
+- Build: ✅ All 3 projects compile successfully
+- Tests: ✅ 615/615 tests pass
+" \
+  --base main \
+  --head feat/integrate-generated-assets
+
+echo "=== PR CREATED ==="

--- a/src/CongCraft.Engine/Audio/AudioSystem.cs
+++ b/src/CongCraft.Engine/Audio/AudioSystem.cs
@@ -119,10 +119,14 @@ public sealed class AudioSystem : ISystem
 
             DevLog.Info("Audio tracks and SFX loaded");
 
-            // Start with menu music
-            _al.SetSourceProperty(_menuSource, SourceFloat.Gain, MusicVolume);
-            _al.SourcePlay(_menuSource);
-            _currentPlaying = GameMode.MainMenu;
+            // Start music matching current game mode (Playing if auto-started)
+            var startMode = GameMode.MainMenu;
+            if (_world.TryGetSingleton<GameStateManager>(out var gsm) && gsm != null)
+                startMode = gsm.CurrentMode;
+            var startSource = GetSourceForMode(startMode);
+            _al.SetSourceProperty(startSource, SourceFloat.Gain, MusicVolume);
+            _al.SourcePlay(startSource);
+            _currentPlaying = startMode;
 
             _initialized = true;
             DevLog.Info("AudioSystem initialized successfully");

--- a/src/CongCraft.Engine/Input/InputSystem.cs
+++ b/src/CongCraft.Engine/Input/InputSystem.cs
@@ -45,7 +45,7 @@ public sealed class InputSystem : ISystem
             mouse.MouseUp += OnMouseUp;
         }
 
-        // Start with mouse free for main menu
+        // Start with mouse free — MenuSystem will capture it when entering gameplay
         _state.IsMouseCaptured = false;
         SetCursorMode(false);
     }

--- a/src/CongCraft.Engine/UI/MenuSystem.cs
+++ b/src/CongCraft.Engine/UI/MenuSystem.cs
@@ -69,9 +69,14 @@ public sealed class MenuSystem : ISystem
         _textRenderer = new TextRenderer(_gl, _font);
         _textures = new UITextureAtlas(_gl);
 
-        // Initialize game state
+        // Initialize game state — auto-start in gameplay mode (ESC for pause menu)
         _gameState = new GameStateManager();
+        _gameState.SetMode(GameMode.Playing);
         _world.SetSingleton(_gameState);
+
+        // Capture mouse for gameplay camera control
+        if (_world.TryGetSingleton<InputState>(out var input) && input != null)
+            input.IsMouseCaptured = true;
 
         // Initialize ember particles
         for (int i = 0; i < _embers.Length; i++)


### PR DESCRIPTION
## Problem

Das Spiel startete im MainMenu-Modus, was alle Gameplay-Systeme blockierte:
- **Kein Laufen**: PlayerMovementSystem prüft GameMode und gibt sofort zurück wenn nicht Playing
- **Kein Spieler sichtbar**: Menu-Overlay (Vollbild-Hintergrund + UI) verdeckte die 3D-Szene
- **Kein Ton**: AudioSystem spielte nur Menü-Musik, kein Exploration/Gameplay-Sound

## Fix

- **MenuSystem**: Startet direkt im Playing-Modus statt MainMenu (ESC öffnet Pause-Menü)
- **MenuSystem**: Maus wird sofort für Kamera-Steuerung eingefangen
- **AudioSystem**: Erkennt aktuellen GameMode beim Init, spielt Exploration-Musik

## Testing

- Build: ✅
- Tests: ✅ 615/615 pass